### PR TITLE
fix empty album name

### DIFF
--- a/src/sub_module/main/SideBar.js
+++ b/src/sub_module/main/SideBar.js
@@ -12,6 +12,9 @@ function SideBar(props) {
 
   function addAlbum() {
     let newAlbumTitle = window.prompt("Enter new album title");
+    if (newAlbumTitle == null || newAlbumTitle == "") {
+      return;
+    }
     axios.post(window.location.origin + "/api/album/new", {
       title: newAlbumTitle
     },


### PR DESCRIPTION
Fixed an issue where an album without a name was created when an album name was not entered.